### PR TITLE
Add Main_Page translation to link to fr wiki mainpage

### DIFF
--- a/lang/fr_FR/LC_MESSAGES/homepage.po
+++ b/lang/fr_FR/LC_MESSAGES/homepage.po
@@ -30,6 +30,10 @@ msgid "Forum"
 msgstr "Forum"
 
 #: index.php:41
+msgid "title=Main_Page"
+msgstr "title=Main_Page/fr"
+
+#: index.php:41
 msgid "Documentation"
 msgstr "Documentation"
 


### PR DESCRIPTION
The aim is to link to french wiki mainpage.